### PR TITLE
Added fileversion twig filter

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -99,8 +99,8 @@ class Plugin extends PluginBase
         // add PHP functions
         $filters += $this->getPhpFunctions();
 
-        // add FileVersion filters
-        $filters += $this->getFileVersion();
+        // add File Version filter
+        $filters += $this->getFileRevision();
 
         return [
             'filters'   => $filters,
@@ -410,21 +410,21 @@ class Plugin extends PluginBase
      *
      * @return string
      */
-    private function getFileVersion()
+    private function getFileRevision()
     {
         return  [
-                'fileversion' => function($filename){
+                'revision' => function($filename, $format = null){
                     // Remove http/web address from the file name if there is one to load it locally
                     $prefix = url("/");
                     $filename_ = trim(preg_replace('/^' . preg_quote($prefix, '/') . '/', '', $filename), '/');
-
                     if (file_exists($filename_))
                     {
                       $timestamp = filemtime($filename_);
-                      return $filename . "?" . date ("m.d.y.H.i.s", $timestamp);
+                      $prepend = ($format) ? date($fomat, $timestamp) : $timestamp;
+                      return $filename . "?" . $prepend;
                     }else
                     {
-                      return $filename . "?";
+                      return $filename;
                     }
                 },
              ];

--- a/Plugin.php
+++ b/Plugin.php
@@ -99,6 +99,9 @@ class Plugin extends PluginBase
         // add PHP functions
         $filters += $this->getPhpFunctions();
 
+        // add FileVersion filters
+        $filters += $this->getFileVersion();
+
         return [
             'filters'   => $filters,
             'functions' => $functions,
@@ -394,5 +397,36 @@ class Plugin extends PluginBase
         $script = '<script type="text/javascript">/*<![CDATA[*/' . $script . '/*]]>*/</script>';
 
         return '<span id="' . $id . '">[javascript protected email address]</span>' . $script;
+    }
+
+    /**
+     * Appends this pattern: ? . {last modified date}
+     * to an assets filename to force browser to reload
+     * cached modified file.
+     *
+     * See: https://github.com/vojtasvoboda/oc-twigextensions-plugin/issues/25
+     *
+     * @param string $filename Filename of the asset file
+     *
+     * @return string
+     */
+    private function getFileVersion()
+    {
+        return  [
+                'fileversion' => function($filename){
+                    // Remove http/web address from the file name if there is one to load it locally
+                    $prefix = url("/");
+                    $filename_ = trim(preg_replace('/^' . preg_quote($prefix, '/') . '/', '', $filename), '/');
+
+                    if (file_exists($filename_))
+                    {
+                      $timestamp = filemtime($filename_);
+                      return $filename . "?" . date ("m.d.y.H.i.s", $timestamp);
+                    }else
+                    {
+                      return $filename . "?";
+                    }
+                },
+             ];
     }
 }

--- a/README.md
+++ b/README.md
@@ -433,7 +433,7 @@ Dumps information about a variable.
 
 ### fileversion
 
-Forces to reload cached modified/updated asset files
+Forces the browser to reload cached modified/updated asset files
 
 #### usage
 ```

--- a/README.md
+++ b/README.md
@@ -431,6 +431,21 @@ Dumps information about a variable.
 <pre>{{ users | var_dump }}</pre>
 ```
 
+### fileversion
+
+Forces to reload cached modified/updated asset files
+
+#### usage
+```
+<img src="{{ 'assets/images/image_file.jpg'|theme|fileversion}}" alt="an image>
+```
+
+Will return something like
+```
+<img src="https://www.example.com/themes/my-theme/assets/image_file.png?12.03.16.04.52.38" alt="an image">
+```
+See: https://github.com/vojtasvoboda/oc-twigextensions-plugin/issues/25
+
 ## Contributing
 
 - [ ] Fix time_diff unit test, which pass at local machine, but fails at TravisCI.

--- a/README.md
+++ b/README.md
@@ -431,20 +431,27 @@ Dumps information about a variable.
 <pre>{{ users | var_dump }}</pre>
 ```
 
-### fileversion
+### revision
+ 
+ Force the browser to reload cached modified/updated asset files.
+ You can provide a format parameter so that the prepended timestamp get converted accordingly to the PHP date() function.
+ 
+ #### usage
+ ```
+ <img src="{{ 'assets/images/image_file.jpg'|theme|revision("m.d.y.H.i.s")}}" alt="an image>
+ ```
+ 
+ Will return something like
+ ```
+ <img src="https://www.example.com/themes/my-theme/assets/image_file.png?12.03.16.04.52.38" alt="an image">
+ ```
 
-Forces the browser to reload cached modified/updated asset files
+ See: https://github.com/vojtasvoboda/oc-twigextensions-plugin/issues/25  
+ 
+      https://stackoverflow.com/questions/32414/how-can-i-force-clients-to-refresh-javascript-files  
 
-#### usage
-```
-<img src="{{ 'assets/images/image_file.jpg'|theme|fileversion}}" alt="an image>
-```
-
-Will return something like
-```
-<img src="https://www.example.com/themes/my-theme/assets/image_file.png?12.03.16.04.52.38" alt="an image">
-```
-See: https://github.com/vojtasvoboda/oc-twigextensions-plugin/issues/25
+      http://php.net/manual/en/function.date.php  
+ 
 
 ## Contributing
 


### PR DESCRIPTION
### fileversion
Forces the browser to reload any cached asset files that have been modified.

#### usage
```
<img src="{{ 'assets/images/image_file.jpg'|theme|fileversion}}" alt="an image>
```

Will return something like
```
<img src="https://www.example.com/themes/my-theme/assets/image_file.png?12.03.16.04.52.38" alt="an image">
```
See: https://github.com/vojtasvoboda/oc-twigextensions-plugin/issues/25