### PR TITLE
Make the plugin work with October 3.x on PHP 8

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -337,7 +337,6 @@ class Plugin extends PluginBase
                 return $result;
             },
             'shuffle' => function ($array) {
-                var_dump($array);
                 if (!is_array($array)) return $array;
 
                 $keys = array_keys($array);

--- a/Plugin.php
+++ b/Plugin.php
@@ -3,13 +3,7 @@
 use App;
 use Backend;
 use Carbon\Carbon;
-use Snilius\Twig\SortByFieldExtension;
 use System\Classes\PluginBase;
-use Twig_Extension_StringLoader;
-use Twig_Extensions_Extension_Array;
-use Twig_Extensions_Extension_Date;
-use Twig_Extensions_Extension_Intl;
-use Twig_Extensions_Extension_Text;
 use VojtaSvoboda\TwigExtensions\Classes\TimeDiffTranslator;
 
 /**
@@ -71,7 +65,13 @@ class Plugin extends PluginBase
         $twig = $this->app->make('twig.environment');
 
         // add String Loader functions
-        $functions += $this->getStringLoaderFunctions($twig);
+        // INFO:
+        /**
+        * things like e.g. wordwrap or truncate can be done in Twig v3.x with
+        * 'Lorem ipsum'|u.wordwrap(5) or
+        * 'Lorem ipsum'|u.truncate(8, '...') repectively.
+        */
+        //$functions += $this->getStringLoaderFunctions($twig);
 
         // add Config function
         $functions += $this->getConfigFunction();
@@ -89,7 +89,13 @@ class Plugin extends PluginBase
         $functions += $this->getVarDumpFunction();
 
         // add Text extensions
-        $filters += $this->getTextFilters($twig);
+        // INFO:
+        /**
+        * things like e.g. wordwrap or truncate can be done in Twig v3.x with
+        * 'Lorem ipsum'|u.wordwrap(5) or
+        * 'Lorem ipsum'|u.truncate(8, '...') repectively.
+        */
+        //$filters += $this->getTextFilters($twig);
 
         // add Intl extensions if php5-intl installed
         if (class_exists('IntlDateFormatter')) {
@@ -97,13 +103,19 @@ class Plugin extends PluginBase
         }
 
         // add Array extensions
-        $filters += $this->getArrayFilters();
+        // INFO:
+        /**
+        * shuffle moved to getPhpFunctions()
+        */
+        //$filters += $this->getArrayFilters();
 
         // add Time extensions
-        $filters += $this->getTimeFilters($twig);
+        // TODO:
+        //$filters += $this->getTimeFilters($twig);
 
         // add Sort by Field extensions
-        $filters += $this->getSortByField();
+        // TODO:
+        //$filters += $this->getSortByField();
 
         // add Mail filters
         $filters += $this->getMailFilters();
@@ -323,6 +335,18 @@ class Plugin extends PluginBase
                 $result = ob_get_clean();
 
                 return $result;
+            },
+            'shuffle' => function ($array) {
+                var_dump($array);
+                if (!is_array($array)) return $array;
+
+                $keys = array_keys($array);
+                shuffle($keys);
+                $random = array();
+                foreach ($keys as $key)
+                    $random[$key] = $array[$key];
+
+                return $random;
             },
         ];
     }

--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,11 @@
     }
   ],
   "require": {
-    "php": ">=7.0.8",
-    "twig/extensions": "~1.5.1",
-    "symfony/translation": "^3.4 || ^4.0",
-    "composer/installers": "^1.10",
-    "snilius/twig-sort-by-field": "dev-master"
+    "php": ">=7.4.3",
+    "twig/intl-extra": "~3.4.2",
+    "twig/extra-bundle": "~3.4.0",
+    "symfony/translation": "^6.1.3",
+    "composer/installers": "^1.10"
   },
   "minimum-stability": "stable",
   "scripts": {

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -1,29 +1,30 @@
-1.0.1: First version of TwigExtensions
-1.0.2: Add template_from_string function
-1.0.3: Fix uppercase, lowercase and ucfirst for UTF-8 characters
-1.0.4: Add leftpad, rightpad and strpad filters. Cover by unit tests.
-1.0.5: Add config function (thanks to Sebastian Hilger)
-1.0.6: Fix localizednumber and localizedcurrency filters (thanks to Vita Zoubek)
-1.0.7: Add the session() and trans() helper functions (thanks to Sebastian Hilger)
-1.0.8: Plugin can be installed over Composer.
-1.0.9: Add var_dump filter and function.
-1.0.10: Remove pre tag from var_dump
-1.0.11: Add mailto filter for rendering encrypted email addresses.
-1.0.12: Add mailto text parameter and rtl filter.
-1.0.13: Make time_diff translatable.
-1.0.14: Add pt-br locale for time_diff translation (thanks to Ronaldo Ribeiro de Sousa)
-1.0.15: Add DE and HU locale (thanks to Szabó Gergő and Sebastian Hilger)
-1.1.0: Make changes for Laravel 5.5.
-1.1.1: Add revision filter
-1.1.2: Add strip_tags filter
-1.1.3: Add sortbyfield filter to sorting arrays/fields by key.
-1.2.0: Require PHP 7.0 as minimum version.
-1.2.1: Add linter and code sniffer for better automatization.
-1.2.2: Add str_replace filter (thanks to Szabó Gergő)
-1.2.3: Added an optional css class parameter to mailto function
-1.2.4: Add sk_SK locale, thanks to Marek Závacký
-1.2.5: Add env() helper function, thanks to Marek Závacký
-1.2.6: Fix ucfirst, thanks to Aurélien Roy
-1.2.7: Add slovenian locale, thanks to Marko Kodrič
-1.3: Fix compatibility with October 2.2.27
-1.3.1: Fix compatibility with October 2.2.27 on PHP 8
+"1.0.1": First version of TwigExtensions
+"1.0.2": Add template_from_string function
+"1.0.3": Fix uppercase, lowercase and ucfirst for UTF-8 characters
+"1.0.4": Add leftpad, rightpad and strpad filters. Cover by unit tests.
+"1.0.5": Add config function (thanks to Sebastian Hilger)
+"1.0.6": Fix localizednumber and localizedcurrency filters (thanks to Vita Zoubek)
+"1.0.7": Add the session() and trans() helper functions (thanks to Sebastian Hilger)
+"1.0.8": Plugin can be installed over Composer.
+"1.0.9": Add var_dump filter and function.
+"1.0.10": Remove pre tag from var_dump
+"1.0.11": Add mailto filter for rendering encrypted email addresses.
+"1.0.12": Add mailto text parameter and rtl filter.
+"1.0.13": Make time_diff translatable.
+"1.0.14": Add pt-br locale for time_diff translation (thanks to Ronaldo Ribeiro de Sousa)
+"1.0.15": Add DE and HU locale (thanks to Szabó Gergő and Sebastian Hilger)
+"1.1.0": Make changes for Laravel 5.5.
+"1.1.1": Add revision filter
+"1.1.2": Add strip_tags filter
+"1.1.3": Add sortbyfield filter to sorting arrays/fields by key.
+"1.2.0": Require PHP 7.0 as minimum version.
+"1.2.1": Add linter and code sniffer for better automatization.
+"1.2.2": Add str_replace filter (thanks to Szabó Gergő)
+"1.2.3": Added an optional css class parameter to mailto function
+"1.2.4": Add sk_SK locale, thanks to Marek Závacký
+"1.2.5": Add env() helper function, thanks to Marek Závacký
+"1.2.6": Fix ucfirst, thanks to Aurélien Roy
+"1.2.7": Add slovenian locale, thanks to Marko Kodrič
+"1.3": Fix compatibility with October 2.2.27
+"1.3.1": Fix compatibility with October 2.2.27 on PHP 8
+"1.4": Try to make the plugin work with October 3.x on PHP 8


### PR DESCRIPTION
This version of the plugin works with October 3.x on PHP 8. Although some filters aren't working anymore. Sorry, I didn't had the time to fix everything.

Not working filters:
- template_from_string
  - Does now exist on Twig 3.x: https://twig.symfony.com/doc/3.x/functions/template_from_string.html
- truncate and wordwrap
  - Can be solved with Twig 3.x `u`
    - `'Lorem ipsum'|u.wordwrap(5)`
    - `'Lorem ipsum'|u.truncate(8, '...')`
- time_diff
  - Not solved
- sortbyfield
  - Not solved
